### PR TITLE
feat: add quest tracking system

### DIFF
--- a/src/gamification/quests.js
+++ b/src/gamification/quests.js
@@ -1,0 +1,64 @@
+const quests = require('./quests.json');
+
+const state = {
+  modules: new Set(),
+  points: 0,
+  completedQuests: new Set()
+};
+
+function addProgress({ module, points = 0 }) {
+  if (module) {
+    state.modules.add(module);
+  }
+  state.points += points;
+  checkQuests();
+}
+
+function checkQuests() {
+  quests.forEach((quest) => {
+    if (state.completedQuests.has(quest.id)) return;
+
+    const modulesDone = quest.requiredModules.every((m) => state.modules.has(m));
+    const enoughPoints = state.points >= quest.requiredPoints;
+
+    if (modulesDone && enoughPoints) {
+      state.completedQuests.add(quest.id);
+      questCompleted(quest.id);
+    }
+  });
+}
+
+function questCompleted(questId) {
+  const quest = quests.find((q) => q.id === questId);
+  if (!quest) return;
+
+  awardXP(quest.rewardXP);
+  awardBadge(quest.rewardBadge);
+  sendExperiencedStatement(questId);
+}
+
+function awardXP(amount) {
+  if (amount > 0) {
+    console.log(`Awarded ${amount} XP for quest.`);
+  }
+}
+
+function awardBadge(badgeId) {
+  if (badgeId) {
+    console.log(`Awarded badge: ${badgeId}`);
+  }
+}
+
+function sendExperiencedStatement(questId) {
+  const statement = {
+    verb: 'experienced',
+    object: { id: questId }
+  };
+  console.log('xAPI statement:', JSON.stringify(statement));
+}
+
+module.exports = {
+  addProgress,
+  state,
+  quests
+};

--- a/src/gamification/quests.json
+++ b/src/gamification/quests.json
@@ -1,0 +1,16 @@
+[
+  {
+    "id": "moduleMaster",
+    "requiredModules": ["intro", "advanced"],
+    "requiredPoints": 100,
+    "rewardXP": 50,
+    "rewardBadge": "module-master"
+  },
+  {
+    "id": "quizWhiz",
+    "requiredModules": ["quiz1", "quiz2", "quiz3"],
+    "requiredPoints": 200,
+    "rewardXP": 100,
+    "rewardBadge": "quiz-whiz"
+  }
+]


### PR DESCRIPTION
## Summary
- Define quests with modules, points, and rewards
- Track progress and trigger quest completion with XP, badges, and xAPI

## Testing
- `node - <<'NODE'
const { addProgress, state } = require('./src/gamification/quests');
addProgress({ module: 'intro', points: 50 });
addProgress({ module: 'advanced', points: 60 });
console.log('Completed:', Array.from(state.completedQuests));
NODE`

------
https://chatgpt.com/codex/tasks/task_b_68a42c3514a8832d9809f53aa61d1ed9