### PR TITLE
Implement badge registry and achievement modal

### DIFF
--- a/src/gamification/badges.js
+++ b/src/gamification/badges.js
@@ -1,0 +1,47 @@
+/**
+ * Badge registry and evaluation helpers.
+ */
+
+export const badgeRegistry = [
+  {
+    id: 'first-completion',
+    name: 'First Completion',
+    description: 'Awarded for completing the first activity',
+    criteria: statement =>
+      statement?.verb?.id === 'http://adlnet.gov/expapi/verbs/completed',
+  },
+];
+
+export const awardedBadges = new Set();
+
+export function awardBadge(badgeId) {
+  if (awardedBadges.has(badgeId)) return;
+  awardedBadges.add(badgeId);
+  console.log(`Badge awarded: ${badgeId}`);
+}
+
+function sendAchievedStatement(badgeId) {
+  const statement = {
+    verb: {
+      id: 'http://adlnet.gov/expapi/verbs/achieved',
+      display: { 'en-US': 'achieved' },
+    },
+    object: { id: `badge:${badgeId}` },
+  };
+
+  // Replace with real xAPI dispatch in production
+  console.log('xAPI statement sent', statement);
+}
+
+export function checkBadgeCriteria(event) {
+  const statement = event?.detail?.statement || event;
+  if (!statement) return;
+
+  badgeRegistry.forEach(badge => {
+    if (!awardedBadges.has(badge.id) && badge.criteria(statement)) {
+      awardBadge(badge.id);
+      sendAchievedStatement(badge.id);
+    }
+  });
+}
+

--- a/src/ui/achievement-modal.js
+++ b/src/ui/achievement-modal.js
@@ -1,0 +1,32 @@
+import { awardedBadges, badgeRegistry } from '../gamification/badges.js';
+
+/**
+ * Displays a modal listing all awarded badges.
+ * @param {HTMLElement} [container=document.body] - Container to append the modal to.
+ */
+export function showAchievementModal(container = document.body) {
+  const modal = document.createElement('div');
+  modal.className = 'achievement-modal';
+
+  const title = document.createElement('h2');
+  title.textContent = 'Achievements';
+  modal.appendChild(title);
+
+  const list = document.createElement('ul');
+  awardedBadges.forEach(id => {
+    const badge = badgeRegistry.find(b => b.id === id);
+    const item = document.createElement('li');
+    item.textContent = badge ? badge.name : id;
+    list.appendChild(item);
+  });
+
+  if (!list.childElementCount) {
+    const empty = document.createElement('li');
+    empty.textContent = 'No badges earned yet.';
+    list.appendChild(empty);
+  }
+
+  modal.appendChild(list);
+  container.appendChild(modal);
+}
+


### PR DESCRIPTION
## Summary
- add badge registry with criteria evaluation and xAPI achieved statements
- render awarded badges via achievement modal UI

## Testing
- `node --check src/gamification/badges.js`
- `node --check src/ui/achievement-modal.js`
- `npm test` *(fails: ENOENT: no such file or directory, open 'package.json')*

------
https://chatgpt.com/codex/tasks/task_b_68a42befc8fc832daeb508dff3a53fd7