### PR TITLE
feat: track activity completion

### DIFF
--- a/src/activity.js
+++ b/src/activity.js
@@ -1,0 +1,9 @@
+import { updateCompletionStatus, applyStoredCompletionStatus } from './gamification/progress.js';
+
+export function onActivityComplete(activityId) {
+  updateCompletionStatus(activityId);
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  applyStoredCompletionStatus();
+});

--- a/src/gamification/progress.js
+++ b/src/gamification/progress.js
@@ -1,0 +1,57 @@
+export function updateCompletionStatus(activityId) {
+  const statement = {
+    verb: {
+      id: 'http://adlnet.gov/expapi/verbs/completed',
+      display: { 'en-US': 'completed' }
+    },
+    object: { id: activityId }
+  };
+
+  try {
+    if (typeof window !== 'undefined' && window.XAPI && typeof window.XAPI.sendStatement === 'function') {
+      window.XAPI.sendStatement(statement);
+    } else if (typeof navigator !== 'undefined' && typeof navigator.sendBeacon === 'function') {
+      navigator.sendBeacon('/xapi/statements', JSON.stringify(statement));
+    } else if (typeof fetch === 'function') {
+      fetch('/xapi/statements', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(statement)
+      });
+    } else {
+      console.log('xAPI statement', statement);
+    }
+  } catch (err) {
+    console.error('Failed to send xAPI statement', err);
+  }
+
+  const el = document.querySelector(`[data-activity-id="${activityId}"]`);
+  if (el) {
+    showCheckmark(el);
+  }
+
+  const completed = JSON.parse(localStorage.getItem('completedActivities') || '{}');
+  completed[activityId] = true;
+  localStorage.setItem('completedActivities', JSON.stringify(completed));
+}
+
+function showCheckmark(el) {
+  let mark = el.querySelector('.checkmark');
+  if (!mark) {
+    mark = document.createElement('span');
+    mark.className = 'checkmark';
+    mark.textContent = '\u2713';
+    el.appendChild(mark);
+  }
+  mark.style.display = 'inline';
+}
+
+export function applyStoredCompletionStatus() {
+  const completed = JSON.parse(localStorage.getItem('completedActivities') || '{}');
+  Object.keys(completed).forEach(id => {
+    const el = document.querySelector(`[data-activity-id="${id}"]`);
+    if (el) {
+      showCheckmark(el);
+    }
+  });
+}


### PR DESCRIPTION
## Summary
- send xAPI completed statements and save activity completions in localStorage
- show checkmarks for completed activities and restore on later visits
- expose onActivityComplete helper that updates completion status

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68a42bb6e818832db2281ec933d0d097