### PR TITLE
feat: add XP awarding and progress display

### DIFF
--- a/src/gamification/xp.js
+++ b/src/gamification/xp.js
@@ -1,0 +1,37 @@
+const XP_STORAGE_KEY = 'xapi-gamify:xp';
+let totalXP = Number(localStorage.getItem(XP_STORAGE_KEY)) || 0;
+
+function sendScoredStatement(points, activityId) {
+  const statement = {
+    verb: {
+      id: 'http://adlnet.gov/expapi/verbs/scored',
+      display: { 'en-US': 'scored' }
+    },
+    object: { id: activityId },
+    result: { score: { raw: points } }
+  };
+
+  if (typeof navigator !== 'undefined' && navigator.sendBeacon && window.LRS_ENDPOINT) {
+    navigator.sendBeacon(window.LRS_ENDPOINT, JSON.stringify(statement));
+  } else {
+    console.log('xAPI scored statement', statement);
+  }
+}
+
+export function awardXP(points, activityId) {
+  totalXP += points;
+  localStorage.setItem(XP_STORAGE_KEY, totalXP);
+  window.dispatchEvent(new CustomEvent('xp:changed', { detail: { xp: totalXP } }));
+  sendScoredStatement(points, activityId);
+}
+
+export function getTotalXP() {
+  return totalXP;
+}
+
+// Listen for the same completion events that drive checkmarks
+// Expected event detail: { xp: <points>, activityId: <id> }
+document.addEventListener('checkmark:completed', (e) => {
+  const { xp = 0, activityId } = e.detail || {};
+  awardXP(xp, activityId);
+});

--- a/src/ui/progress-bar.js
+++ b/src/ui/progress-bar.js
@@ -1,0 +1,13 @@
+import { getTotalXP } from '../gamification/xp.js';
+
+export default function initProgressBar(element) {
+  function render() {
+    const xp = getTotalXP();
+    const level = Math.floor(xp / 100);
+    const nextLevel = (level + 1) * 100;
+    element.textContent = `XP: ${xp} / ${nextLevel} (Level ${level})`;
+  }
+
+  render();
+  window.addEventListener('xp:changed', render);
+}


### PR DESCRIPTION
## Summary
- track and award XP via `awardXP` and emit xAPI `scored` statements
- listen for `checkmark:completed` events to grant XP
- show total XP, level, and next level threshold in progress bar

## Testing
- `npm test` *(fails: package.json missing)*


------
https://chatgpt.com/codex/tasks/task_b_68a42bd7a4f0832d8a5148b0ac3bb046