### PR TITLE
Add FAST-like prototype proposal

### DIFF
--- a/FAST-prototype.md
+++ b/FAST-prototype.md
@@ -1,0 +1,28 @@
+# FAST-lignende prototypeløsning
+
+Fokus på rask oppbygging av korte, engasjerende treninger med gamification, publisering uten "tung" LMS, og enkel admin.
+
+## Modulbibliotek (byggeklosser i editoren)
+
+### Innholdsmoduler
+- Intro/Hero: tittel, undertittel, bakgrunnsbilde/video.
+- Innholdskort: tekst + bilde/ikon (1–3 kolonner).
+- Video: kilde (mp4/YouTube/Vimeo), transkripsjon, teksting.
+- Bilde m/tekst: bildetekst, zoom/lysbildeshow.
+- Sitat/Case: sitat + person/rolle/foto.
+- Prosedyre/Steg-for-steg: liste med steg, hvert steg kan ha bilde eller kort video.
+- Nedlastbart: lenke til PDF, sjekklister, maler.
+- Callout/Tips: varselboks med ikon og farge (info, advarsel, suksess).
+
+### Interaksjonsmoduler
+- Quiz – flervalg: 1 riktig / flere riktige, forklaring etter svar.
+- Quiz – drag-and-drop: match begreper til kategorier.
+- Scenario (grenlogikk light): 2–3 valg fører til ulik feedback, ev. poeng.
+- Kunnskapskontroll: 3–5 spørsmål, terskel for bestått.
+- Mikrooppgave: "Finn riktig vurdering i bildet" (hotspots).
+
+### Gamification (inn/av per kurs)
+- XP per modul/aktivitet, badges for milepæler, streaks (valgfritt), målskjerm ved bestått.
+- Konfetti/lyd ved modul/eksamen fullført.
+- Progressbar og checkmarks.
+


### PR DESCRIPTION
## Summary
- document a FAST-style training prototype with content modules, interactions, and gamification options

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68a464ed4db4832dbda1538e49d05b69